### PR TITLE
Support TrueNAS 2025.10

### DIFF
--- a/update_cert.py
+++ b/update_cert.py
@@ -87,7 +87,7 @@ assert str(new_certificate["id"]) in ui_certificates
 print(f"Activating new cert: {new_cert_id}")
 response = requests.put(f"{API_BASE_URL}/system/general",
                         headers=headers,
-                        json={"ui_certificate": str(new_cert_id)},
+                        json={"ui_certificate": new_cert_id},
                         verify=False)
 response.raise_for_status()
 

--- a/update_cert.py
+++ b/update_cert.py
@@ -142,7 +142,8 @@ for cert_id in ui_certificates.keys():
     except Exception:
         print(f"Failed to delete cert {cert_id}, skip")
 
-time.sleep(3)
-
 print("Reloading TrueNAS web UI")
-req_get(f"{API_BASE_URL}/system/general/ui_restart")
+
+# Default wait is 3 seconds
+response = requests.post(f"{API_BASE_URL}/system/general/ui_restart", headers=headers, verify=False)
+response.raise_for_status()


### PR DESCRIPTION
This pull request fixes issues I hit on 2025.10.  I've also tested the updated version on my older node still running 25.04.2.6.  This stuff is pretty minor, but it was enough to cause the script to fail for me.

```bash
root@latruenas[~/certs]# python update_cert.py
Testing Connection TrueNAS
Detected TrueNAS (25, 10, 1), using app path of app
Uploading cert with name cert_20260311 to TrueNAS
New certificate 'cert_20260311' created
Fetching list of installed UI certificates
Activating new cert: 28
Traceback (most recent call last):
  File "/root/certs/update_cert.py", line 92, in <module>
    response.raise_for_status()
  File "/usr/lib/python3/dist-packages/requests/models.py", line 1021, in raise_for_status
    raise HTTPError(http_error_msg, response=self)
requests.exceptions.HTTPError: 422 Client Error: Unprocessable Entity for url: https://localhost:443/api/v2.0/system/general`
```

Switching the `ui_certificate` parameter to an integer (rather than a string) got me past this first error and the hit a second error on the restart:

```bash
root@latruenas[~/certs]# python update_cert.py
Testing Connection TrueNAS
Detected TrueNAS (25, 10, 1), using app path of app
Fetching list of installed UI certificates
Activating new cert: 28
Certificate update completed.
Deleting old certificate
Reloading TrueNAS web UI
Traceback (most recent call last):
  File "/root/certs/update_cert.py", line 148, in <module>
    req_get(f"{API_BASE_URL}/system/general/ui_restart")
  File "/root/certs/update_cert.py", line 33, in req_get
    response.raise_for_status()
  File "/usr/lib/python3/dist-packages/requests/models.py", line 1021, in raise_for_status
    raise HTTPError(http_error_msg, response=self)
requests.exceptions.HTTPError: 405 Client Error: Method Not Allowed for url: https://localhost:443/api/v2.0/system/general/ui_restart
```

It seems like `GET` is no longer allowed.  REST API [docs](https://www.truenas.com/docs/api/scale_rest_api.html) says it's supported, but I suspect it just isn't updated yet.  Honestly, a restart on a "GET" request is pretty odd.